### PR TITLE
Fix bug with pattern matching when passing globs

### DIFF
--- a/lib/git_stage_formatter.rb
+++ b/lib/git_stage_formatter.rb
@@ -2,7 +2,8 @@ require_relative "git_stage_formatter/version"
 
 module GitStageFormatter
   def self.run(args)
-    args = args.join(' ')
+    # Wrap each argument in quotes to handle spaces in paths
+    args = args.map { |arg| "\"#{arg}\"" }.join(' ')
     script_path = File.expand_path('../git-format-staged', File.dirname(__FILE__))
     exec("#{script_path} #{args}")
   end


### PR DESCRIPTION
## Description

Before, this code:

```sh
bundle exec git_stage_formatter --formatter \"$LINTER_BIN --autocorrect-all --stderr --stdin '{}'\" "*.rb" "Gemfile" "bin/*" "*.ru" 2>/dev/null
```

Would expand the patterns and pass some matches to the python script instead, e.g.:

```
ruby script_path = /Users/rogerluan/Documents/Projects/git_stage_formatter/git-format-staged, args = --formatter "/Users/rogerluan/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.56.2/exe/rubocop --autocorrect-all --stderr --stdin {}" *.rb Gemfile bin/* *.ru
file_patterns = ['a_ruby_file.rb', 'another_ruby_file.rb', 'Gemfile', 'bin/bundle', 'bin/rails', 'bin/rake', 'bin/setup', 'config.ru']
```

Now it will wrap the patterns around double quotes, so the python script will receive the patterns untouched, e.g.:

```
ruby script_path = /Users/rogerluan/Documents/Projects/git_stage_formatter/git-format-staged, args = "--formatter" ""/Users/rogerluan/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.56.2/exe/rubocop" "--autocorrect-all" "--stderr" "--stdin" "{}"" "*.rb" "Gemfile" "bin/*" "*.ru"
file_patterns = ['*.rb', 'Gemfile', 'bin/*', '*.ru']
```